### PR TITLE
Bookkeeping changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This is the working area for the  IETF SACM terminology draft.
 * [Editor's copy](https://sacmwg.github.io/draft-ietf-sacm-terminology/)
 * [Working Group Draft] (https://tools.ietf.org/html/draft-ietf-sacm-terminology)
 * [Compare Working Group and Editor's Drafts] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-sacm-terminology&url2=https://sacmwg.github.io/draft-ietf-sacm-terminology/draft-ietf-sacm-terminology.txt)
+
 ## Contributing
 
 Before submitting feedback, please familiarize yourself with our current issues

--- a/draft-ietf-sacm-terminology.md
+++ b/draft-ietf-sacm-terminology.md
@@ -1,8 +1,7 @@
 ---
 title: Secure Automation and Continuous Monitoring (SACM) Terminology
 abbrev: SACM Terminology
-docname: draft-ietf-sacm-terminology-07
-date: 2015-07-06
+docname: draft-ietf-sacm-terminology-latest
 stand_alone: true
 ipr: trust200902
 area: Security


### PR DESCRIPTION
A couple of bookkeeping changes:

Fix a format error in the readme
Make the date be the date it was generated rather than a fixed date
Change the document title to be more generic as it does not match the published numbered version on the IETF website.
